### PR TITLE
Replace invalid package

### DIFF
--- a/cmd/metrics-bench/metrics-bench.go
+++ b/cmd/metrics-bench/metrics-bench.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"go-metrics"
 	"time"
+
+	"github.com/pavel-kolesnikov/go-metrics"
 )
 
 func main() {

--- a/cmd/metrics-example/metrics-example.go
+++ b/cmd/metrics-example/metrics-example.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"errors"
-	"go-metrics"
 	// "go-metrics/stathat"
 	"log"
 	"math/rand"
 	"os"
 	// "syslog"
 	"time"
+
+	"github.com/pavel-kolesnikov/go-metrics"
 )
 
 const fanout = 10


### PR DESCRIPTION
Replace invalid package `go-metrics` to `github.com/pavel-kolesnikov/go-metrics` if passible.

Package management tools (such as [glide](https://github.com/Masterminds/glide)) outputs warnings.
